### PR TITLE
display_information:   name: azure-support   description: Bot to help…

### DIFF
--- a/slack_app_manifest.yaml
+++ b/slack_app_manifest.yaml
@@ -15,6 +15,11 @@ features:
       type: global
       callback_id: open_azure_support_ticket
       description: Open an Azure Support Ticket
+  slash_commands:
+    - command: /azure-support
+      url: https://YOUR-DOMAIN-NAME/slack/events
+      description: Open an Azure Support Ticket
+      should_escape: false
 oauth_config:
   scopes:
     bot:


### PR DESCRIPTION
… with Azure Support   background_color: "#35373d" features:   app_home:     home_tab_enabled: true     messages_tab_enabled: false     messages_tab_read_only_enabled: true   bot_user:     display_name: azure-support     always_online: true   shortcuts:     - name: azure-support       type: global       callback_id: open_azure_support_ticket       description: Open an Azure Support Ticket   slash_commands:     - command: /azure-support       url: https://YOUR-DOMAIN-NAME/slack/events       description: Open an Azure Support Ticket       should_escape: false oauth_config:   scopes:     bot:       - channels:history       - chat:write       - users:read       - users:read.email       - reactions:write       - commands       - app_mentions:read       - groups:read       - channels:read settings:   event_subscriptions:     request_url: https://YOUR-DOMAIN-NAME/slack/events     bot_events:       - message.channels   interactivity:     is_enabled: true     request_url: https://YOUR-DOMAIN-NAME/slack/events     message_menu_options_url: https://YOUR-DOMAIN-NAME/slack/events   org_deploy_enabled: false   socket_mode_enabled: false   token_rotation_enabled: false

Fixes missing slash_commands configuration in Slack App Manifest that causes /azure-support command failures

**Problem:**
The current Slack App Manifest is missing the `slash_commands` section entirely, which causes the `/azure-support` slash command to fail with "dispatch_failed" error. Users can only access the bot through the global shortcut, not the slash command.

**Root Cause:**
- Manifest defines global shortcuts 
- Manifest missing slash_commands section 
- This is a companion issue to the missing @app.command() handler in app.py

**Solution:**
Added the missing `slash_commands` section to enable the /azure-support command:

```yaml
slash_commands:
  - command: /azure-support
    url: https://YOUR-DOMAIN-NAME/slack/events
    description: Open an Azure Support Ticket
    should_escape: false